### PR TITLE
TrackParamACTSSeeding::SpacePoint: remove unachievable constexpr

### DIFF
--- a/JugTrack/src/components/TrackParamACTSSeeding.cpp
+++ b/JugTrack/src/components/TrackParamACTSSeeding.cpp
@@ -101,8 +101,8 @@ namespace Jug::Reco {
             constexpr float x() const { return position.x; }
             constexpr float y() const { return position.y; }
             constexpr float z() const { return position.z; }
-            constexpr float r() const { return std::hypot(x(), y()); }
-            constexpr float varianceR() const
+            float r() const { return std::hypot(x(), y()); }
+            float varianceR() const
             {
                 return (std::pow(x(), 2) * positionError.xx +
                         std::pow(y(), 2) * positionError.yy) /


### PR DESCRIPTION
The std::hypot and std::pow are not constexpr in the current C++
standards.

Fixes error on clang/libc++:
```
src/components/TrackParamACTSSeeding.cpp:104:29: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
            constexpr float r() const { return std::hypot(x(), y()); }
                            ^
src/components/TrackParamACTSSeeding.cpp:104:48: note: non-constexpr function 'hypot' cannot be used in a constant expression
            constexpr float r() const { return std::hypot(x(), y()); }
                                               ^
/nix/store/pn15cirhh9m1wzfkjj2jyfa9s2f4483l-libcxx-11.1.0-dev/include/c++/v1/math.h:1255:46: note: declared here
inline _LIBCPP_INLINE_VISIBILITY float       hypot(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::hypotf(__lcpp_x, __lcpp_y);}
                                             ^
src/components/TrackParamACTSSeeding.cpp:105:29: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
            constexpr float varianceR() const
                            ^
src/components/TrackParamACTSSeeding.cpp:107:25: note: non-constexpr function 'pow<float, int>' cannot be used in a constant expression
                return (std::pow(x(), 2) * positionError.xx +
                        ^
libcxx-11.1.0-dev/include/c++/v1/math.h:992:1: note: declared here
pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
^
```